### PR TITLE
fixup! download: Add snap warning

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -222,12 +222,14 @@
     </ol>
   </details>
 
+  {% if page.version > 3 %}
   <details>
     <summary><strong>{{page.snap_instructions}}</strong></summary>
 
     <p>{{page.snap_warning}}</p>
 
   </details>
+  {% endif %}
 
   <h2 style="text-align: center">{{page.build_reproduction}}</h2>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -5,7 +5,7 @@ type: pages
 layout: page
 lang: en
 share: false
-version: 3
+version: 4
 
 ## These strings need to be localized.  In the listing below, the
 ## comment above each entry contains the English text.  The key before the


### PR DESCRIPTION
Adds text versioning for the translation integration.  Suggest you squash this into your commit.